### PR TITLE
Decision and meeting

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,8 +8,8 @@
 * [Response to reports](response/about.md)
    * [Initial response](response/initial_response.md)
    * [Team meeting](response/team_meeting_1.md)
-   * [Write up initial report](response/intial_writeup.md)
-   * [Decision & sanctions](response/decision.md)
+      * [Write up initial report](response/intial_writeup.md)
+      * [Decision & sanctions](response/decision.md)
    * ["The talk"](response/talk.md)
    * [Team meeting & followups](response/team_meeting_2.md)
    * [Communication & reporting](response/communication.md)
@@ -23,4 +23,3 @@
    * [Internal reporting](templates/reporting.md)
    * [Incidents tracking](templates/spreadsheet.md)
 * [Acknowledgements](thanks.md)
-

--- a/response/decision.md
+++ b/response/decision.md
@@ -1,13 +1,38 @@
 # Decision & sanctions
 
+Most Code of Conduct issues you're going to deal with are minor, and the goal is
+to achieve common understanding with all involved parties. However, no matter
+how minor or major your incident is, you need a usually quick decision on what to do.
+
+In our process, we usually make assumptions about possible outcome before even
+going to meet the reported person. If the talk goes well, and they see their mistake, a
+ warning is usually enough. If a slide violated Code of Conduct, we will make sure
+ it's removed from published version of the talk, so on and so on.
+
+However, your decision may change if during the talk it will be made clear that
+offender indeed meant harm, or just "did not care". In this case, you should not
+make a decision on spot, but meet with your Response Team to decide a new sanction
+after "the talk"
+
+The possible sanctions might be different if the offender feels sorry for their actions
+or if they are defensive and angry about the report. It may also depend on whether their
+actions were deliberate or they intended no harm.
+
+Most Code of Conduct incidents reach a common understanding, and giving people a warning
+to allow them to correct their actions in the future is the key.
 
 ## Possible sanctions
-Your guiding principle should be the safety of your community members from harassment and you should evaluate sanctions in light of whether they provide the safety needed. You and your event are the only people who can judge appropriate sanctions in your community based on the nature of the incident and the responses of the people involved, but some possibilities are:
+
+Your guiding principle should be the safety of your community members from harassment
+and you should evaluate sanctions in light of whether they provide the safety needed.
+You and your event are the only people who can judge appropriate sanctions in your
+community based on the nature of the incident and the responses of the people involved,
+but some possibilities are:
 
 - warning the harasser to cease their behaviour and that any further reports will result in sanctions
 - requiring that the harasser avoid any interaction with, and physical proximity to, their victim for the remainder of the event
 - ending a talk that violates the policy early
-- not publishing the video or slides of a talk that violated the policy
+- not publishing the video or particular slide of a talk that violated the policy
 - not allowing a speaker who violated the policy to give (further) talks at this conference events
 - immediately ending any event volunteer responsibilities and privileges the harasser holds
 - requiring that the harasser not volunteer for future events your organization runs (either indefinitely or for a certain time period)

--- a/response/decision.md
+++ b/response/decision.md
@@ -1,25 +1,28 @@
 # Decision & sanctions
 
-Most Code of Conduct issues you're going to deal with are minor, and the goal is
+Many of Code of Conduct issues you're going to deal with will be minor incidents, and the goal is
 to achieve common understanding with all involved parties. However, no matter
-how minor or major your incident is, you need a usually quick decision on what to do.
+how minor or major your incident is, you need to make sure to react quickly and decide on the steps as soon as possible.
 
 In our process, we usually make assumptions about possible outcome before even
-going to meet the reported person. If the talk goes well, and they see their mistake, a
+going to meet the reported person. In case of minor incidents, if the talk goes well, and they see their mistake, a
  warning is usually enough. If a slide violated Code of Conduct, we will make sure
- it's removed from published version of the talk, so on and so on.
+ it's removed from published version of the talk, is the tweet was offending, we ask author to remove it, so on and so on.
 
-However, your decision may change if during the talk it will be made clear that
+However, your decision may change if during the talk it will be clear that
 offender indeed meant harm, or just "did not care". In this case, you should not
 make a decision on spot, but meet with your Response Team to decide a new sanction
-after "the talk"
+after "the talk". 
 
 The possible sanctions might be different if the offender feels sorry for their actions
 or if they are defensive and angry about the report. It may also depend on whether their
 actions were deliberate or they intended no harm.
 
 Most Code of Conduct incidents reach a common understanding, and giving people a warning
-to allow them to correct their actions in the future is the key.
+to allow them to correct their actions in the future is the best solution in the situation. 
+
+In case the offender poses a threat to other attendees or organizers of the event, Response Team 
+could take more extreme steps to ensure safety of everyone at the event.
 
 ## Possible sanctions
 

--- a/response/team_meeting_1.md
+++ b/response/team_meeting_1.md
@@ -14,7 +14,7 @@ Goals of the meeting:
 	Member who received the report should fill everyone in, and if the report
 	has been written down, everyone should also read it. If the situation is
 	time-sensitive or someone is in physical danger, you need to stop now and take
-	immediate action: keep people safe. If the issue is not time-sensitive, make sure
+	immediate action: keep people safe first. If the issue is not time-sensitive, make sure
 	the reporter already knows that you're working on resolving it. Only then carry
 	on.
 - **Document and write an internal report**
@@ -24,7 +24,8 @@ Goals of the meeting:
 	Refer to your Code of Conduct text if needed. If you've got trouble seeing it,
 	it might be a good idea to meet with the reporter again and politely ask them
 	to provide more context. Do not try to invalidate their feelings though:
-	*everyone* has the right to feel offended.
+	*everyone* has the right to feel offended. You should not express your judgment or opinions 
+	about the event during this talk.
 - **Decide if you need to speak with involved sides**
 	This is usually a good idea. If you haven't met with your reporter yet and you
 	feel like more context is required, do this first. Speaking with people with the

--- a/response/team_meeting_1.md
+++ b/response/team_meeting_1.md
@@ -1,20 +1,37 @@
 # Team meeting
 
-Available staff - ideally whole Code of Conduct Response Team or as many members 
-of the team as possible - should meet immediately after receiving a report to:
+Available staff - ideally whole Code of Conduct Response Team or as many members
+of the team as possible - should meet immediately after receiving a report.
 
-- discuss what happened and what is the current situation;
-- decide if you need to speak with involved sides;
-- decide on possible actions, but make sure to not make them definite and base 
-them depending on person reaction. For instance, the sanctions might be different 
-if the offender feels sorry for their actions or if they are defensive and 
-angry about the report. It may also depend on whether their actions were deliberate or they intended no harm. Most Code of Conduct incidents reach a common understanding, and giving people a warning to allow them to correct their actions in the future is the key;
-- try to document these steps in your internal report;
-- decide who is going to speak with involved sides - ideally two people: 
-woman and man;
-- decide when you should talk to involved sides.
-
-**Neither the complainant nor the alleged harasser should attend.** 
+**Neither the complainant nor the alleged harasser should attend.**
 People with a conflict of interest should exclude themselves or if necessary be excluded by others.
 
-If the event was widely witnessed, make sure that you let people know that the Code of Conduct team is taking care of the issue. 
+If the event was widely witnessed, make sure that you let people know that the Code of Conduct team is taking care of the issue.
+
+Goals of the meeting:
+
+- **Discuss what happened and what is the current situation**  
+	Member who received the report should fill everyone in, and if the report
+	has been written down, everyone should also read it. If the situation is
+	time-sensitive or someone is in physical danger, you need to stop now and take
+	immediate action: keep people safe. If the issue is not time-sensitive, make sure
+	the reporter already knows that you're working on resolving it. Only then carry
+	on.
+- **Document and write an internal report**
+	We go over details of why this is important at this point in [Write the initial report subchapter](response/intial_writeup.md).
+- **Decide if the described issue violates Code of Conduct**
+	In most cases, the issue is black and white, and decision is straightforward.
+	Refer to your Code of Conduct text if needed. If you've got trouble seeing it,
+	it might be a good idea to meet with the reporter again and politely ask them
+	to provide more context. Do not try to invalidate their feelings though:
+	*everyone* has the right to feel offended.
+- **Decide if you need to speak with involved sides**
+	This is usually a good idea. If you haven't met with your reporter yet and you
+	feel like more context is required, do this first. Speaking with people with the
+	idea to achieve common understanding is the key to most Code of Conduct violations.
+	If you're going to arrange meetings, never speak to both reporter and offender
+	at the same time -- these should be two separate meetings. This decision should
+	also include *who* is going to talk to them and *when*.
+- **Decide on possible outcome**
+	But make sure to not make them definite and base them depending on person reaction.
+	Refer to our [Decision & sanctions subchapter](response/decision.md).


### PR DESCRIPTION
This is moving around some stuff to make: 
- Team meeting chapter more structurized, explaining clearly what should happen during a meeting
- Decision & report chapters are now subchapters of Team meeting
- Mooooar stuff in decision chapter + moved some stuff from "Team meeting" to "Decision", as they're more relevant there.
