### PR TITLE
Add Creative Commons acknowledgements and author listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Feel free to use it to learn about our process, or to implement similar process 
 
 This work is by:
 
+ - Ola Sendecka
  - Ola Sitarska
 
 This work incorporates and is derived from Creative Commons licenced work by:

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ This work incorporates and is derived from Creative Commons licenced work by
 the following authors:
 
  * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history]([http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
- * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/](PyCon Staff Procedure for Handling Harassment)
+ * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/]
  * authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ This is a document used by [Django: Under the Hood](djangounderthehood.com) and 
 It's a very early draft, and things change as we learn more about things that work for us.
 
 Feel free to use it to learn about our process, or to implement similar process in your community.
+
+### Authors
+
+This work is by:
+ * Ola Sitarska
+
+This work incorporates and is derived from Creative Commons licenced work by
+the following authors:
+
+ * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history]([http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
+ * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/](PyCon Staff Procedure for Handling Harassment)
+ * authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This work is by:
 
  - Ola Sitarska
 
-This work incorporates and is derived from Creative Commons licenced work by
-the following authors:
+This work incorporates and is derived from Creative Commons licenced work by:
 
  - [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
  - authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Feel free to use it to learn about our process, or to implement similar process 
 
 This work is by:
 
- * Ola Sitarska
+ - Ola Sitarska
 
 This work incorporates and is derived from Creative Commons licenced work by
 the following authors:
 
- * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
- * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)
- * authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)
+ - [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
+ - authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)
+ - authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ This work incorporates and is derived from Creative Commons licenced work by
 the following authors:
 
  * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history]([http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
- * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/]
+ * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)
  * authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Feel free to use it to learn about our process, or to implement similar process 
 ### Authors
 
 This work is by:
+
  * Ola Sitarska
 
 This work incorporates and is derived from Creative Commons licenced work by

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ This work is by:
 This work incorporates and is derived from Creative Commons licenced work by
 the following authors:
 
- * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history]([http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
+ * [Mary Gardiner](https://mary.gardiner.id.au/) (User:Thayvian), User:Azurelunatic, and other editors of the Geek Feminism wiki listed at [Responding to reports revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports?action=history) and [Duty officer revision history](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer?action=history)
  * authors of the [PyCon Staff Procedure for Handling Harassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)
  * authors of the [Django Code of Conduct - Reporting Guide](https://www.djangoproject.com/conduct/reporting/)

--- a/thanks.md
+++ b/thanks.md
@@ -1,6 +1,6 @@
 # Acknowledgements
 
-This work is derived from the following Creative Commons licenced resources:
+This work is derived from the following Creative Commons licenced works:
 
 - [Geek Feminism Wikia: Responding to reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)
 - [Geek Feminism Wikia: Duty officer](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer)

--- a/thanks.md
+++ b/thanks.md
@@ -1,5 +1,7 @@
 # Acknowledgements
 
+This work is derived from the following Creative Commons licenced resources:
+
 - [Geek Feminism Wikia: Responding to reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)
 - [Geek Feminism Wikia: Duty officer](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Duty_officer)
 - [PyCon US Staff Procedure for Handling Harrassment](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents-staff/)


### PR DESCRIPTION
Hi,

At the moment, the coc-handbook source does not properly acknowledge the authors of the works this is based on. It has an Acknowledgements section, but this looks like you are listing further reading, or helpful resources. It's not clear at the moment that the works you link there are actually incorporated into your handbook.

This pull request adds more detailed acknowledgement of the your co-authors/derived works in a way that should be clearer and comply with Creative Commons Attribution-Sharealike.

Thanks,

Mary Gardiner
